### PR TITLE
fix: use public billing API for Copilot quota after OpenCode partnership change

### DIFF
--- a/plugin/lib/i18n.ts
+++ b/plugin/lib/i18n.ts
@@ -107,6 +107,20 @@ const translations = {
     overageRequests: "次请求",
     quotaResets: "配额重置",
     resetsSoon: "即将重置",
+    modelBreakdown: "模型使用明细:",
+    billingPeriod: "计费周期",
+    copilotQuotaUnavailable:
+      "⚠️ GitHub Copilot 配额查询暂时不可用。\n" +
+      "OpenCode 的新 OAuth 集成不支持访问配额 API。",
+    copilotQuotaWorkaround:
+      "解决方案:\n" +
+      "1. 创建一个 fine-grained PAT (访问 https://github.com/settings/tokens?type=beta)\n" +
+      "2. 在 'Account permissions' 中将 'Plan' 设为 'Read-only'\n" +
+      "3. 创建配置文件 ~/.config/opencode/copilot-quota-token.json:\n" +
+      '   {"token": "github_pat_xxx...", "username": "你的用户名"}\n\n' +
+      "其他方法:\n" +
+      "• 在 VS Code 中点击状态栏的 Copilot 图标查看配额\n" +
+      "• 访问 https://github.com/settings/billing 查看使用情况",
   },
   en: {
     // 时间单位
@@ -171,6 +185,20 @@ const translations = {
     overageRequests: "requests",
     quotaResets: "Quota resets",
     resetsSoon: "Resets soon",
+    modelBreakdown: "Model breakdown:",
+    billingPeriod: "Period",
+    copilotQuotaUnavailable:
+      "⚠️ GitHub Copilot quota query unavailable.\n" +
+      "OpenCode's new OAuth integration doesn't support quota API access.",
+    copilotQuotaWorkaround:
+      "Solution:\n" +
+      "1. Create a fine-grained PAT (visit https://github.com/settings/tokens?type=beta)\n" +
+      "2. Under 'Account permissions', set 'Plan' to 'Read-only'\n" +
+      "3. Create config file ~/.config/opencode/copilot-quota-token.json:\n" +
+      '   {"token": "github_pat_xxx...", "username": "YourUsername"}\n\n' +
+      "Alternatives:\n" +
+      "• Click the Copilot icon in VS Code status bar to view quota\n" +
+      "• Visit https://github.com/settings/billing for usage info",
   },
 } as const;
 

--- a/plugin/lib/types.ts
+++ b/plugin/lib/types.ts
@@ -51,6 +51,28 @@ export interface CopilotAuthData {
 }
 
 /**
+ * Copilot subscription tier
+ * See: https://docs.github.com/en/copilot/about-github-copilot/subscription-plans-for-github-copilot
+ */
+export type CopilotTier = "free" | "pro" | "pro+" | "business" | "enterprise";
+
+/**
+ * Copilot quota token configuration
+ * Stored in ~/.config/opencode/copilot-quota-token.json
+ *
+ * Users can create a fine-grained PAT with "Plan" read permission
+ * to enable quota checking via the public GitHub REST API.
+ */
+export interface CopilotQuotaConfig {
+  /** Fine-grained PAT with "Plan" read permission */
+  token: string;
+  /** GitHub username (for API calls) */
+  username: string;
+  /** Copilot subscription tier (determines monthly quota limit) */
+  tier: CopilotTier;
+}
+
+/**
  * Antigravity 账号（来自 ~/.config/opencode/antigravity-accounts.json）
  */
 export interface AntigravityAccount {


### PR DESCRIPTION
## Summary

OpenCode's new OAuth integration (Jan 2026 partnership with GitHub) doesn't grant access to the internal `/copilot_internal/*` endpoints, causing quota queries to return 404 errors. This PR adds support for querying quota via GitHub's public billing API.

## Changes

- Add `CopilotQuotaConfig` type with `token`, `username`, and `tier` fields
- Add `CopilotTier` type for subscription tiers: `free`, `pro`, `pro+`, `business`, `enterprise`
- Read config from `~/.config/opencode/copilot-quota-token.json`
- Call public API: `GET /users/{username}/settings/billing/premium_request/usage`
- Format response with progress bar, model breakdown, and billing period
- Fall back to internal API for legacy tokens (backward compatible)
- Add helpful setup instructions in error messages (English & Chinese)

## Tier Limits

| Tier | Monthly Premium Requests |
|------|-------------------------|
| free | 50 |
| pro | 300 |
| pro+ | 1500 |
| business | 300 |
| enterprise | 1000 |

## Setup

Users need to create a fine-grained PAT with "Plan" read permission:

1. Visit https://github.com/settings/tokens?type=beta
2. Create new token with "Account permissions" → "Plan" → "Read-only"
3. Create config file `~/.config/opencode/copilot-quota-token.json`:

```json
{
  "token": "github_pat_xxx...",
  "username": "YourUsername",
  "tier": "pro"
}
```

## Example Output

```
Account:        GitHub Copilot (@username)

Premium        ████████████████░░░░ 80% (60/300)

Model breakdown:
  Claude Opus 4.5: 60 requests

Period: 2026-01
```