### PR TITLE
fix: skip Google quota check when Antigravity is not configured

### DIFF
--- a/plugin/lib/google.ts
+++ b/plugin/lib/google.ts
@@ -7,6 +7,7 @@
  * [同步]: mystatus.ts, types.ts, utils.ts, i18n.ts
  */
 
+import { existsSync } from "fs";
 import { readFile } from "fs/promises";
 import { homedir } from "os";
 import { join } from "path";
@@ -301,10 +302,16 @@ function formatAccountQuota(quotaInfo: AccountQuotaInfo): string {
  * 查询所有 Antigravity 账号的额度
  * @returns 查询结果
  */
-export async function queryGoogleUsage(): Promise<QueryResult> {
+export async function queryGoogleUsage(): Promise<QueryResult | null> {
+  const accountsPath = getAntigravityAccountsPath();
+
+  if (!existsSync(accountsPath)) {
+    return null;
+  }
+
   try {
     // 读取账号文件
-    const content = await readFile(getAntigravityAccountsPath(), "utf-8");
+    const content = await readFile(accountsPath, "utf-8");
     const file = JSON.parse(content) as AntigravityAccountsFile;
 
     if (!file.accounts || file.accounts.length === 0) {


### PR DESCRIPTION
## Summary

Avoid noisy errors when Google/Antigravity is not configured.

## What changed

- return `null` from the Google quota checker when `~/.config/opencode/antigravity-accounts.json` does not exist
- keep Google quota checks opt-in, matching how other providers are skipped when no auth/config is available

## Why

`/mystatus` currently reports an error for users who do not use Antigravity at all, because the Google checker always tries to read the Antigravity accounts file.

This makes the plugin noisier than necessary for setups where Google support is unused.

## Result

Users without Antigravity configured no longer see an unnecessary error, while configured Google users keep the existing behavior.

Fixes #13